### PR TITLE
Fix for handleapi error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ tinyfiledialogs = "^3"
 libc = "^0"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "^0.3", features = ["namedpipeapi" , "synchapi" ] }
+winapi = { version = "^0.3", features = ["namedpipeapi" , "synchapi" , "handleapi" ] }
 os_str_bytes = "^2"
 
 [dev-dependencies]


### PR DESCRIPTION
`handleapi` part of `winapi` crate is used, but feature wasn't listed.