### PR TITLE
Put Edge last in the Windows paths list

### DIFF
--- a/src/locate.rs
+++ b/src/locate.rs
@@ -32,13 +32,13 @@ fn paths() -> &'static [&'static str] {
 #[cfg(target_os = "windows")]
 fn paths() -> [String; 7] {
     [
-        var("ProgramFiles(x86)").unwrap() + "/Microsoft/Edge/Application/msedge.exe",
         var("LocalAppData").unwrap() + "/Google/Chrome/Application/chrome.exe",
         var("ProgramFiles").unwrap() + "/Google/Chrome/Application/chrome.exe",
         var("ProgramFiles(x86)").unwrap() + "/Google/Chrome/Application/chrome.exe",
         var("LocalAppData").unwrap() + "/Chromium/Application/chrome.exe",
         var("ProgramFiles").unwrap() + "/Chromium/Application/chrome.exe",
         var("ProgramFiles(x86)").unwrap() + "/Chromium/Application/chrome.exe",
+        var("ProgramFiles(x86)").unwrap() + "/Microsoft/Edge/Application/msedge.exe",
     ]
 }
 


### PR DESCRIPTION
This PR just puts the path for MS Edge at the end of the Windows paths list. Since Edge is available by default on recent Windows versions, having it last lets the user use Chrome without having to uninstall Edge first.

Edge currently has a bug where it pins itself to the taskbar on first run regardless of the `--no-first-run` argument (see https://github.com/JackD83/ALVR/issues/305 for details). This PR serves as a more immediate fix for the issue as opposed to #11.